### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/crowpi.yml
+++ b/.github/workflows/crowpi.yml
@@ -2,18 +2,23 @@ name: CrowPi CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       ################################################################################
       # Checkout repository with submodules
       ################################################################################
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           fetch-depth: 0
@@ -33,5 +38,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main'
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
This PR updates all included GitHub action plugins and switches the GH Pages deployment from deploy-key-based to token-based. Tests conducted directly on the branch were successful. However, I will merge this via PR as well to ensure that both flows are handled smoothly.