### PR TITLE
Update Hugo and fix FHNW header image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Hugo
 /public
 /resources/_gen
+/.hugo_build.lock
 
 # Eclipse
 .classpath

--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,8 @@ home = ["HTML", "RSS", "JSON"]
 weight = 1
 contentDir = "content/german"
 languageName = "German"
+
+[languages.de.params]
 landingPageName = "<i class='fas fa-fw fa-home'></i> Startseite"
 landingPageURL = "/CrowPiGoesJavaTutorial/de"
 
@@ -20,6 +22,9 @@ landingPageURL = "/CrowPiGoesJavaTutorial/de"
 weight = 2
 contentDir = "content/english"
 languageName = "English"
+
+[languages.en.params]
+landingPageName = "<i class='fas fa-fw fa-home'></i> Home"
 landingPageURL = "/CrowPiGoesJavaTutorial/en"
 
 [[menu.shortcuts]]

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,4 +1,4 @@
 <a id="logo" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>
-    <img src="{{ "/images/fhnw-logo.svg" | relURL }}" style="width: 40%; height: 40%">
+    <img src="{{ "images/fhnw-logo.svg" | relURL }}" style="width: 40%; height: 40%">
     <h3 style="margin: 0; color: white;">CrowPi goes Java</h3>
 </a>


### PR DESCRIPTION
This PR does a couple things:

- Fix the broken image reference to the FHNW logo in the site header
- Update the `.gitignore` to also exclude the new Hugo build lock file
- Refactor the deprecated Hugo language-specific params into their own section